### PR TITLE
1. Fix node with different parents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 # both are optional, depending on platform
 gem 'fast_stack'
-gem 'stackprof', platform: :mri_21
+gem 'stackprof', platform: [:mri_21, :mri_22, :mri_23]
+

--- a/lib/flamegraph/renderer.rb
+++ b/lib/flamegraph/renderer.rb
@@ -32,12 +32,13 @@ class Flamegraph::Renderer
       next unless stack
 
       col = []
+      new_col = false
 
       reversed_stack = stack.reverse
       reversed_stack.map{|r| r.to_s}.each_with_index do |frame, i|
         parent_frame = i > 0 ? reversed_stack[i - 1] : nil
 
-        if !prev[i].nil?
+        if !prev[i].nil? && !new_col
           last_col = prev[i]
           frame_match = last_col[0] == frame
           parent_match = parent_frame.nil? || prev_parent[i].nil? || parent_frame == prev_parent[i]
@@ -46,6 +47,8 @@ class Flamegraph::Renderer
             last_col[1] += 1
             col << nil
             next
+          else
+            new_col = true
           end
         end
 

--- a/lib/flamegraph/renderer.rb
+++ b/lib/flamegraph/renderer.rb
@@ -24,6 +24,7 @@ class Flamegraph::Renderer
   def graph_data
     table = []
     prev = []
+    prev_parent = []
 
     # a 2d array makes collapsing easy
     @stacks.each_with_index do |stack, pos|
@@ -32,11 +33,16 @@ class Flamegraph::Renderer
 
       col = []
 
-      stack.reverse.map{|r| r.to_s}.each_with_index do |frame, i|
+      reversed_stack = stack.reverse
+      reversed_stack.map{|r| r.to_s}.each_with_index do |frame, i|
+        parent_frame = i > 0 ? reversed_stack[i - 1] : nil
 
         if !prev[i].nil?
           last_col = prev[i]
-          if last_col[0] == frame
+          frame_match = last_col[0] == frame
+          parent_match = parent_frame.nil? || prev_parent[i].nil? || parent_frame == prev_parent[i]
+
+          if frame_match && parent_match
             last_col[1] += 1
             col << nil
             next
@@ -44,6 +50,7 @@ class Flamegraph::Renderer
         end
 
         prev[i] = [frame, 1]
+        prev_parent[i] = parent_frame
         col << prev[i]
       end
       prev = prev[0..col.length-1].to_a

--- a/test/test_renderer.rb
+++ b/test/test_renderer.rb
@@ -17,6 +17,21 @@ class TestRenderer < Minitest::Test
 
   end
 
+  def test_builds_table_correctly_for_different_grandparents
+    stacks = [["method4","method3","method1"],["method4","method3","method1"],["method4","method3","method2"]]
+
+    g = Flamegraph::Renderer.new(stacks)
+    assert_equal([
+        {:x => 1, :y => 1, :frame => "method1", :width => 2},
+        {:x => 1, :y => 2, :frame => "method3", :width => 2},
+        {:x => 1, :y => 3, :frame => "method4", :width => 2},
+        {:x => 3, :y => 1, :frame => "method2", :width => 1},
+        {:x => 3, :y => 2, :frame => "method3", :width => 1},
+        {:x => 3, :y => 3, :frame => "method4", :width => 1}
+    ], g.graph_data)
+
+  end
+
   def test_avoids_bridges
     stacks = [["3","2","1"],["4","1"],["4","5"]]
 

--- a/test/test_renderer.rb
+++ b/test/test_renderer.rb
@@ -10,8 +10,9 @@ class TestRenderer < Minitest::Test
         {:x => 1, :y => 1, :frame => "1", :width => 2},
         {:x => 1, :y => 2, :frame => "2", :width => 1},
         {:x => 1, :y => 3, :frame => "3", :width => 1},
-        {:x => 2, :y => 2, :frame => "4", :width => 2},
-        {:x => 3, :y => 1, :frame => "5", :width => 1}
+        {:x => 2, :y => 2, :frame => "4", :width => 1},
+        {:x => 3, :y => 1, :frame => "5", :width => 1},
+        {:x => 3, :y => 2, :frame => "4", :width => 1}
     ], g.graph_data)
 
   end
@@ -25,8 +26,9 @@ class TestRenderer < Minitest::Test
         {:x => 1, :y => 1, :frame => "1", :width => 2},
         {:x => 1, :y => 2, :frame => "2", :width => 1},
         {:x => 1, :y => 3, :frame => "3", :width => 1},
-        {:x => 2, :y => 2, :frame => "4", :width => 2},
-        {:x => 3, :y => 1, :frame => "5", :width => 1}
+        {:x => 2, :y => 2, :frame => "4", :width => 1},
+        {:x => 3, :y => 1, :frame => "5", :width => 1},
+        {:x => 3, :y => 2, :frame => "4", :width => 1}
     ], g.graph_data)
 
 


### PR DESCRIPTION
This PR fixes the case where `method1` and `method2` both call `method3` and `method3` appears as one long node instead of two shorter nodes.